### PR TITLE
feat(dental-clinic-back): implement entity relationships with Hibernate

### DIFF
--- a/src/main/java/com/dh/Dental/Clinic/controller/AppointmentController.java
+++ b/src/main/java/com/dh/Dental/Clinic/controller/AppointmentController.java
@@ -1,0 +1,63 @@
+package com.dh.Dental.Clinic.controller;
+
+import com.dh.Dental.Clinic.entity.Appointment;
+
+import com.dh.Dental.Clinic.service.IAppointmentService;
+
+import org.springframework.http.ResponseEntity;
+
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import java.util.Optional;
+
+@RestController
+
+@RequestMapping("/appointments")
+
+public class AppointmentController {
+
+    private final IAppointmentService appointmentService;
+
+    public AppointmentController(IAppointmentService appointmentService) {
+
+        this.appointmentService = appointmentService;
+
+    }
+
+    @PostMapping("/save")
+
+    public ResponseEntity<Appointment> saveAppointment(@RequestBody Appointment appointment) {
+
+        return ResponseEntity.ok(appointmentService.saveAppointment(appointment));
+
+    }
+
+    @GetMapping("/find/{id}")
+
+    public ResponseEntity<Appointment> findAppointmentById(@PathVariable Integer id) {
+
+        Optional<Appointment> appointment = appointmentService.findAppointmentById(id);
+
+        if (appointment.isPresent()) {
+
+            return ResponseEntity.ok(appointment.get());
+
+        } else {
+
+            return ResponseEntity.notFound().build();
+
+        }
+
+    }
+
+    @GetMapping("/all")
+
+    public ResponseEntity<List<Appointment>> findAllAppointments() {
+
+        return ResponseEntity.ok(appointmentService.findAllAppointments());
+
+    }
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/controller/DentistController.java
+++ b/src/main/java/com/dh/Dental/Clinic/controller/DentistController.java
@@ -1,0 +1,63 @@
+package com.dh.Dental.Clinic.controller;
+
+import com.dh.Dental.Clinic.entity.Dentist;
+
+import com.dh.Dental.Clinic.service.IDentistService;
+
+import org.springframework.http.ResponseEntity;
+
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import java.util.Optional;
+
+@RestController
+
+@RequestMapping("/dentists")
+
+public class DentistController {
+
+    private final IDentistService dentistService;
+
+    public DentistController(IDentistService dentistService) {
+
+        this.dentistService = dentistService;
+
+    }
+
+    @PostMapping("/save")
+
+    public ResponseEntity<Dentist> saveDentist(@RequestBody Dentist dentist) {
+
+        return ResponseEntity.ok(dentistService.saveDentist(dentist));
+
+    }
+
+    @GetMapping("/find/{id}")
+
+    public ResponseEntity<Dentist> findDentistById(@PathVariable Integer id) {
+
+        Optional<Dentist> dentist = dentistService.findDentistById(id);
+
+        if (dentist.isPresent()) {
+
+            return ResponseEntity.ok(dentist.get());
+
+        } else {
+
+            return ResponseEntity.notFound().build();
+
+        }
+
+    }
+
+    @GetMapping("/all")
+
+    public ResponseEntity<List<Dentist>> findAllDentists() {
+
+        return ResponseEntity.ok(dentistService.findAllDentists());
+
+    }
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/controller/PatientController.java
+++ b/src/main/java/com/dh/Dental/Clinic/controller/PatientController.java
@@ -1,0 +1,63 @@
+package com.dh.Dental.Clinic.controller;
+
+import com.dh.Dental.Clinic.entity.Patient;
+
+import com.dh.Dental.Clinic.service.IPatientService;
+
+import org.springframework.http.ResponseEntity;
+
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import java.util.Optional;
+
+@RestController
+
+@RequestMapping("/patients")
+
+public class PatientController {
+
+    private final IPatientService patientService;
+
+    public PatientController(IPatientService patientService) {
+
+        this.patientService = patientService;
+
+    }
+
+    @PostMapping("/save")
+
+    public ResponseEntity<Patient> savePatient(@RequestBody Patient patient) {
+
+        return ResponseEntity.ok(patientService.savePatient(patient));
+
+    }
+
+    @GetMapping("/find/{id}")
+
+    public ResponseEntity<Patient> findPatientById(@PathVariable Integer id) {
+
+        Optional<Patient> patient = patientService.findPatientById(id);
+
+        if (patient.isPresent()) {
+
+            return ResponseEntity.ok(patient.get());
+
+        } else {
+
+            return ResponseEntity.notFound().build();
+
+        }
+
+    }
+
+    @GetMapping("/all")
+
+    public ResponseEntity<List<Patient>> findAllPatients() {
+
+        return ResponseEntity.ok(patientService.findAllPatients());
+
+    }
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/entity/Address.java
+++ b/src/main/java/com/dh/Dental/Clinic/entity/Address.java
@@ -1,0 +1,41 @@
+package com.dh.Dental.Clinic.entity;
+
+import jakarta.persistence.*;
+
+import lombok.AllArgsConstructor;
+
+import lombok.Getter;
+
+import lombok.NoArgsConstructor;
+
+import lombok.Setter;
+
+@Getter
+
+@Setter
+
+@NoArgsConstructor
+
+@AllArgsConstructor
+
+@Entity
+
+@Table(name = "addresses")
+
+public class Address {
+
+    @Id
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+
+    private Integer id;
+
+    private String street;
+
+    private int number;
+
+    private String locality;
+
+    private String province;
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/entity/Appointment.java
+++ b/src/main/java/com/dh/Dental/Clinic/entity/Appointment.java
@@ -1,0 +1,55 @@
+package com.dh.Dental.Clinic.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
+import jakarta.persistence.*;
+
+import lombok.AllArgsConstructor;
+
+import lombok.Getter;
+
+import lombok.NoArgsConstructor;
+
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+
+@Setter
+
+@NoArgsConstructor
+
+@AllArgsConstructor
+
+@Entity
+
+@Table(name = "appointments")
+
+public class Appointment {
+
+    @Id
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+
+    private Integer id;
+
+    @ManyToOne
+
+    @JoinColumn(name = "patient_id") // Relación Muchos a Uno con Patient
+
+    @JsonBackReference(value = "patient-appointment")
+
+    private Patient patient;
+
+    @ManyToOne
+
+    @JoinColumn(name = "dentist_id") // Relación Muchos a Uno con Dentist
+
+    @JsonBackReference(value = "dentist-appointment")
+
+    private Dentist dentist;
+
+    private LocalDate date;
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/entity/Dentist.java
+++ b/src/main/java/com/dh/Dental/Clinic/entity/Dentist.java
@@ -1,0 +1,49 @@
+package com.dh.Dental.Clinic.entity;
+
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
+import jakarta.persistence.*;
+
+import lombok.AllArgsConstructor;
+
+import lombok.Getter;
+
+import lombok.NoArgsConstructor;
+
+import lombok.Setter;
+
+import java.util.Set;
+
+@Getter
+
+@Setter
+
+@NoArgsConstructor
+
+@AllArgsConstructor
+
+@Entity
+
+@Table(name = "dentists")
+
+public class Dentist {
+
+    @Id
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+
+    private Integer id;
+
+    private String registrationNumber;
+
+    private String lastName;
+
+    private String firstName;
+
+    @OneToMany(mappedBy = "dentist", cascade = CascadeType.REMOVE)
+
+    @JsonManagedReference(value = "dentist-appointment")
+
+    private Set<Appointment> appointments; // Relación Uno a Muchos con Appointment
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/entity/Patient.java
+++ b/src/main/java/com/dh/Dental/Clinic/entity/Patient.java
@@ -1,0 +1,57 @@
+package com.dh.Dental.Clinic.entity;
+
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
+import jakarta.persistence.*;
+
+import lombok.AllArgsConstructor;
+
+import lombok.Getter;
+
+import lombok.NoArgsConstructor;
+
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+import java.util.Set;
+
+@Getter
+
+@Setter
+
+@NoArgsConstructor
+
+@AllArgsConstructor
+
+@Entity
+
+@Table(name = "patients")
+
+public class Patient {
+
+    @Id
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+
+    private Integer id;
+
+    private String lastName;
+
+    private String firstName;
+
+    private String dni;
+
+    private LocalDate admissionDate;
+
+    @OneToOne(cascade = CascadeType.ALL)
+
+    private Address address; // Relación Uno a Uno con Address
+
+    @OneToMany(mappedBy = "patient", cascade = CascadeType.ALL)
+
+    @JsonManagedReference(value = "patient-appointment")
+
+    private Set<Appointment> appointments; // Relación Uno a Muchos con Appointment
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/repository/IAddressRepository.java
+++ b/src/main/java/com/dh/Dental/Clinic/repository/IAddressRepository.java
@@ -1,0 +1,13 @@
+package com.dh.Dental.Clinic.repository;
+
+import com.dh.Dental.Clinic.entity.Address;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+
+public interface IAddressRepository extends JpaRepository<Address, Integer> {
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/repository/IAppointmentRepository.java
+++ b/src/main/java/com/dh/Dental/Clinic/repository/IAppointmentRepository.java
@@ -1,0 +1,13 @@
+package com.dh.Dental.Clinic.repository;
+
+import com.dh.Dental.Clinic.entity.Appointment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+
+public interface IAppointmentRepository extends JpaRepository<Appointment, Integer> {
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/repository/IDentistRepository.java
+++ b/src/main/java/com/dh/Dental/Clinic/repository/IDentistRepository.java
@@ -1,0 +1,13 @@
+package com.dh.Dental.Clinic.repository;
+
+import com.dh.Dental.Clinic.entity.Dentist;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+
+public interface IDentistRepository extends JpaRepository<Dentist, Integer> {
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/repository/IPatientRepository.java
+++ b/src/main/java/com/dh/Dental/Clinic/repository/IPatientRepository.java
@@ -1,0 +1,13 @@
+package com.dh.Dental.Clinic.repository;
+
+import com.dh.Dental.Clinic.entity.Patient;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+
+public interface IPatientRepository extends JpaRepository<Patient, Integer> {
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/service/IAddressService.java
+++ b/src/main/java/com/dh/Dental/Clinic/service/IAddressService.java
@@ -1,0 +1,9 @@
+package com.dh.Dental.Clinic.service;
+
+import com.dh.Dental.Clinic.entity.Address;
+
+public interface IAddressService {
+
+    Address saveAddress(Address address);
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/service/IAppointmentService.java
+++ b/src/main/java/com/dh/Dental/Clinic/service/IAppointmentService.java
@@ -1,0 +1,17 @@
+package com.dh.Dental.Clinic.service;
+
+import com.dh.Dental.Clinic.entity.Appointment;
+
+import java.util.List;
+
+import java.util.Optional;
+
+public interface IAppointmentService {
+
+    Appointment saveAppointment(Appointment appointment);
+
+    Optional<Appointment> findAppointmentById(Integer id);
+
+    List<Appointment> findAllAppointments();
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/service/IDentistService.java
+++ b/src/main/java/com/dh/Dental/Clinic/service/IDentistService.java
@@ -1,0 +1,17 @@
+package com.dh.Dental.Clinic.service;
+
+import com.dh.Dental.Clinic.entity.Dentist;
+
+import java.util.List;
+
+import java.util.Optional;
+
+public interface IDentistService {
+
+    Dentist saveDentist(Dentist dentist);
+
+    Optional<Dentist> findDentistById(Integer id);
+
+    List<Dentist> findAllDentists();
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/service/IPatientService.java
+++ b/src/main/java/com/dh/Dental/Clinic/service/IPatientService.java
@@ -1,0 +1,17 @@
+package com.dh.Dental.Clinic.service;
+
+import com.dh.Dental.Clinic.entity.Patient;
+
+import java.util.List;
+
+import java.util.Optional;
+
+public interface IPatientService {
+
+    Patient savePatient(Patient patient);
+
+    Optional<Patient> findPatientById(Integer id);
+
+    List<Patient> findAllPatients();
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/service/impl/AddressService.java
+++ b/src/main/java/com/dh/Dental/Clinic/service/impl/AddressService.java
@@ -1,0 +1,31 @@
+package com.dh.Dental.Clinic.service.impl;
+
+import com.dh.Dental.Clinic.entity.Address;
+
+import com.dh.Dental.Clinic.repository.IAddressRepository;
+
+import com.dh.Dental.Clinic.service.IAddressService;
+
+import org.springframework.stereotype.Service;
+
+@Service
+
+public class AddressService implements IAddressService {
+
+    private final IAddressRepository addressRepository;
+
+    public AddressService(IAddressRepository addressRepository) {
+
+        this.addressRepository = addressRepository;
+
+    }
+
+    @Override
+
+    public Address saveAddress(Address address) {
+
+        return addressRepository.save(address);
+
+    }
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/service/impl/AppointmentService.java
+++ b/src/main/java/com/dh/Dental/Clinic/service/impl/AppointmentService.java
@@ -1,0 +1,51 @@
+package com.dh.Dental.Clinic.service.impl;
+
+import com.dh.Dental.Clinic.entity.Appointment;
+
+import com.dh.Dental.Clinic.repository.IAppointmentRepository;
+
+import com.dh.Dental.Clinic.service.IAppointmentService;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import java.util.Optional;
+
+@Service
+
+public class AppointmentService implements IAppointmentService {
+
+    private final IAppointmentRepository appointmentRepository;
+
+    public AppointmentService(IAppointmentRepository appointmentRepository) {
+
+        this.appointmentRepository = appointmentRepository;
+
+    }
+
+    @Override
+
+    public Appointment saveAppointment(Appointment appointment) {
+
+        return appointmentRepository.save(appointment);
+
+    }
+
+    @Override
+
+    public Optional<Appointment> findAppointmentById(Integer id) {
+
+        return appointmentRepository.findById(id);
+
+    }
+
+    @Override
+
+    public List<Appointment> findAllAppointments() {
+
+        return appointmentRepository.findAll();
+
+    }
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/service/impl/DentistService.java
+++ b/src/main/java/com/dh/Dental/Clinic/service/impl/DentistService.java
@@ -1,0 +1,51 @@
+package com.dh.Dental.Clinic.service.impl;
+
+import com.dh.Dental.Clinic.entity.Dentist;
+
+import com.dh.Dental.Clinic.repository.IDentistRepository;
+
+import com.dh.Dental.Clinic.service.IDentistService;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import java.util.Optional;
+
+@Service
+
+public class DentistService implements IDentistService {
+
+    private final IDentistRepository dentistRepository;
+
+    public DentistService(IDentistRepository dentistRepository) {
+
+        this.dentistRepository = dentistRepository;
+
+    }
+
+    @Override
+
+    public Dentist saveDentist(Dentist dentist) {
+
+        return dentistRepository.save(dentist);
+
+    }
+
+    @Override
+
+    public Optional<Dentist> findDentistById(Integer id) {
+
+        return dentistRepository.findById(id);
+
+    }
+
+    @Override
+
+    public List<Dentist> findAllDentists() {
+
+        return dentistRepository.findAll();
+
+    }
+
+}

--- a/src/main/java/com/dh/Dental/Clinic/service/impl/PatientService.java
+++ b/src/main/java/com/dh/Dental/Clinic/service/impl/PatientService.java
@@ -1,0 +1,51 @@
+package com.dh.Dental.Clinic.service.impl;
+
+import com.dh.Dental.Clinic.entity.Patient;
+
+import com.dh.Dental.Clinic.repository.IPatientRepository;
+
+import com.dh.Dental.Clinic.service.IPatientService;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import java.util.Optional;
+
+@Service
+
+public class PatientService implements IPatientService {
+
+    private final IPatientRepository patientRepository;
+
+    public PatientService(IPatientRepository patientRepository) {
+
+        this.patientRepository = patientRepository;
+
+    }
+
+    @Override
+
+    public Patient savePatient(Patient patient) {
+
+        return patientRepository.save(patient);
+
+    }
+
+    @Override
+
+    public Optional<Patient> findPatientById(Integer id) {
+
+        return patientRepository.findById(id);
+
+    }
+
+    @Override
+
+    public List<Patient> findAllPatients() {
+
+        return patientRepository.findAll();
+
+    }
+
+}


### PR DESCRIPTION
Implementation of Entity Relationships in the Dental Clinic Project
This pull request includes the implementation of the relationships between the main entities of the Dental Clinic system using Hibernate and JPA. The following entities have been implemented and their relationships defined:

Address: Represents the address of a patient.

Patient: Includes a one-to-one relationship with Address and a one-to-many relationship with Appointment.

Dentist: Includes a one-to-many relationship with Appointment.

Appointment: Relates a patient to a dentist, allowing appointments to be managed.

Implementation Details:
The entity classes have been created in the entity package and the JPA annotations have been correctly configured to establish the relationships between them.

Repositories have been created for each entity in the repository package to allow data access using JpaRepository.

Services have been implemented in the service package that handle the business logic related to the entities.

Controllers have been developed in the controller package to manage CRUD requests associated with entities.